### PR TITLE
Fix for memory leaks

### DIFF
--- a/LMAlertView/LMAlertView.m
+++ b/LMAlertView/LMAlertView.m
@@ -532,6 +532,10 @@
 		[self removeFromSuperview];
 		
 		// Release window from memory
+        if (self.window.rootViewController.presentedViewController) {
+            [self.window.rootViewController.presentedViewController dismissViewControllerAnimated:NO completion:nil];
+        }
+        self.window.rootViewController = nil;
 		self.window.hidden = YES;
 		self.window = nil;
 		

--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,8 @@
 platform :ios, '7.0'
 
+target 'LMAlertViewDemo' do
 pod 'EDStarRating', '~> 1.1'
 pod 'RBBAnimation', '~> 0.3.0'
 pod 'CAAnimationBlocks', '~> 0.0.1'
 pod 'LMFixedTextView', :git => 'https://github.com/lmcd/LMFixedTextView.git'
+end


### PR DESCRIPTION
## Description
This PR fix some memory leaks.

 For some reason it is still not releasing `UIWindow` and `LMNavigationBar`immediately after alert is dismissed, but it never instantiate more than 1 of each at the same time, so the next time an alert is presented, previous window and navigationBar are released before creating new ones.