### PR TITLE
Prevent crash when accessing delegate after it has been released

### DIFF
--- a/LMAlertView/LMAlertView.h
+++ b/LMAlertView/LMAlertView.h
@@ -34,7 +34,7 @@
 @property (nonatomic, strong) UIColor *tintColor;
 @property (nonatomic, strong, readonly) UIView *contentView;
 @property (nonatomic) BOOL keepTopAlignment;
-@property (unsafe_unretained) id<UIAlertViewDelegate> delegate;
+@property (weak) id<UIAlertViewDelegate> delegate;
 
 @property(nonatomic) NSInteger cancelButtonIndex;
 @property(nonatomic, readonly) NSInteger firstOtherButtonIndex;


### PR DESCRIPTION
## Description
We have a crash related to LMAlertView when accessing its delegate. See https://fabric.io/orchid/ios/apps/com.cipherhealth.orchid/issues/59c5a040be077a4dcc154ba8?time=last-ninety-days

I believe it is related to delegate declared as `unsafe_unretained`.